### PR TITLE
bme280: Correct code samples for negative values

### DIFF
--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -138,9 +138,9 @@ print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
 
 H, T = bme280.humi()
 if T<0 then    
-  print(string.format("-%d.%02d", -T/100, -T%100))
+  print(string.format("T=-%d.%02d", -T/100, -T%100))
 else
-  print(string.format("%d.%02d", T/100, T%100))
+  print(string.format("T=%d.%02d", T/100, T%100))
 end
 print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
 D = bme280.dewpoint(H, T)
@@ -154,9 +154,9 @@ end
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
 if curAlt<0 then
-  print(string.format("-%d.%02d", -curAlt/100, -curAlt%100))
+  print(string.format("altitude=-%d.%02d", -curAlt/100, -curAlt%100))
 else
-  print(string.format("%d.%02d", curAlt/100, curAlt%100))
+  print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
 end
 ```
 
@@ -200,9 +200,9 @@ bme280.init(3, 4, nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
   T, P = bme280.read()
   if T<0 then
-    print(string.format("-%d.%02d", -T/100, -T%100))
+    print(string.format("T=-%d.%02d", -T/100, -T%100))
   else
-    print(string.format("%d.%02d", T/100, T%100))
+    print(string.format("T=%d.%02d", T/100, T%100))
   end
 end)
 ```

--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -137,15 +137,27 @@ QNH = bme280.qfe2qnh(P, alt)
 print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
 
 H, T = bme280.humi()
-print(string.format("T=%d.%02d", T/100, T%100))
+if T<0 then    
+  print(string.format("-%d.%02d", -T/100, -T%100))
+else
+  print(string.format("%d.%02d", T/100, T%100))
+end
 print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
 D = bme280.dewpoint(H, T)
-print(string.format("dew_point=%d.%02d", D/100, D%100))
+if D<0 then
+  print(string.format("dew_point=-%d.%02d", -D/100, -D%100))
+else
+  print(string.format("dew_point=%d.%02d", D/100, D%100))
+end
 
 -- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
-print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
+if curAlt<0 then
+  print(string.format("-%d.%02d", -curAlt/100, -curAlt%100))
+else
+  print(string.format("%d.%02d", curAlt/100, curAlt%100))
+end
 ```
 
 Or simpler and more efficient
@@ -155,17 +167,29 @@ alt=320 -- altitude of the measurement place
 bme280.init(3, 4)
 
 T, P, H, QNH = bme280.read(alt)
-print(string.format("T=%d.%02d", T/100, T%100))
+if T<0 then
+  print(string.format("T=-%d.%02d", -T/100, -T%100))
+else
+  print(string.format("T=%d.%02d", T/100, T%100))
+end
 print(string.format("QFE=%d.%03d", P/1000, P%1000))
 print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
 print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
 D = bme280.dewpoint(H, T)
-print(string.format("dew_point=%d.%02d", D/100, D%100))
+if D<0 then
+  print(string.format("dew_point=-%d.%02d", -D/100, -D%100))
+else
+  print(string.format("dew_point=%d.%02d", D/100, D%100))
+end
 
 -- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
-print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
+if curAlt<0 then
+  print(string.format("altitude=-%d.%02d", -curAlt/100, -curAlt%100))
+else
+  print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
+end
 ```
 
 Use `bme280.init(sda, scl, 1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
@@ -175,7 +199,11 @@ Example of readout in forced mode (asynchronous)
 bme280.init(3, 4, nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
   T, P = bme280.read()
-  print(string.format("T=%d.%02d", T/100, T%100))
+  if T<0 then
+    print(string.format("-%d.%02d", -T/100, -T%100))
+  else
+    print(string.format("%d.%02d", T/100, T%100))
+  end
 end)
 ```
 


### PR DESCRIPTION
Fixes #1734.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

The formatting/modulo will produce wrong values for negative numbers. Corrected the samples to make it work